### PR TITLE
Add Scratch pad, event listener for textarea input, function to load content from the file into the textarea, call loadFileContent on page load

### DIFF
--- a/source/main.css
+++ b/source/main.css
@@ -143,12 +143,19 @@ body {
   padding: 10px;
 }
 
-.scratchPad{
+#scratchPadInput {
     margin-top: 15px;
     margin-left: 15px;
     width: 270px;
     height: 260px;
-    background-color: #FFEFB7;
+  background-color: #ffefb7;
+  color: rgba(0, 0, 0, 0.5);
+  font-size: 15px;
+  font-family: Nunito;
+  font-weight: 700;
+  word-wrap: break-word; /* Removed the quotes around break-word */
+  border: none;
+  box-shadow: 10px 10px 20px rgba(0, 0, 0, 0.15); /* Example shadow */
 }
 
 .toolbar{

--- a/source/main.html
+++ b/source/main.html
@@ -54,8 +54,8 @@
                     <div id="Calendar">
                         <calendar-component id="calendar"></calendar-component>
                     </div>
-                    <div class="scratchPad">
-                        <div class="UseMeAsAScratchPad" style="color: rgba(0, 0, 0, 0.50); font-size: 15px; font-family: Nunito; font-weight: 700; word-wrap: break-word">Use me as a scratch pad...</div>
+                    <div class="scratchPad" >
+                        <textarea id="scratchPadInput" placeholder="Type your text here..."></textarea>
                     </div>
                 </div>
             </div>

--- a/source/swipeAnimation.js
+++ b/source/swipeAnimation.js
@@ -34,5 +34,30 @@ window.addEventListener('load', function () {
     const filename = "journals/"+date.toDateString() + '.md';
     markdown_editor.filename = filename;
   }
-});
 
+  const textarea = this.document.getElementById("scratchPadInput");
+  let file = App.get_file_store().get_file("scratch.txt");
+  if (file) {
+    textarea.value = file.get_content();
+  }
+  textarea.addEventListener("input", () => {
+    const content = textarea.value;
+    if (content) {
+      let file = App.get_file_store().get_file("scratch.txt");
+      if (!file) {
+        file = App.get_file_store().create_file("scratch.txt");
+      }
+      textarea.addEventListener("input", () => {
+        const content = textarea.value;
+        if (content) {
+          let file = App.get_file_store().get_file("scratch.txt");
+          if (!file) {
+            file = App.get_file_store().create_file("scratch.txt");
+          }
+          file.set_content(content);
+          App.get_file_store().sync();
+        }
+      });
+    }
+  });
+});


### PR DESCRIPTION
When click the scratch pad within the Journal View, it will first store into the pad, and then save to scratch.txt of the Project view bars